### PR TITLE
cleanup

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,18 +1,14 @@
 #!/usr/bin/env node
 /*jslint node: true */
-(function () {
-    "use strict";
+var unbrowserify = require("./unbrowserify"),
+    filename,
+    outputDirectory;
 
-    var unbrowserify = require("./unbrowserify"),
-        filename,
-        outputDirectory;
+if (process.argv.length <= 2) {
+    console.error("Usage: " + process.argv.join(" ") + " Source [Outdir]");
+    process.exit();
+}
 
-    if (process.argv.length <= 2) {
-        console.error("Usage: " + process.argv.join(" ") + " Source [Outdir]");
-        process.exit();
-    }
-
-    filename = process.argv[2];
-    outputDirectory = process.argv.length >= 4 ? process.argv[3] : ".";
-    unbrowserify.unbrowserify(filename, outputDirectory);
-}());
+filename = process.argv[2];
+outputDirectory = process.argv.length >= 4 ? process.argv[3] : ".";
+unbrowserify.unbrowserify(filename, outputDirectory);

--- a/decompress.js
+++ b/decompress.js
@@ -1,211 +1,209 @@
 /*jslint node: true */
-(function () {
-    "use strict";
+"use strict";
 
-    var uglifyJS = require("uglifyjs"),
-        defaultOptions = {
-            constants: true,
-            sequences: true,
-            conditionals: true
-        };
+var uglifyJS = require("uglifyjs"),
+    defaultOptions = {
+        constants: true,
+        sequences: true,
+        conditionals: true
+    };
 
-    function asStatement(node) {
-        if (node instanceof uglifyJS.AST_Statement) {
-            return node;
-        }
-        return new uglifyJS.AST_SimpleStatement({ body: node });
+function asStatement(node) {
+    if (node instanceof uglifyJS.AST_Statement) {
+        return node;
+    }
+    return new uglifyJS.AST_SimpleStatement({ body: node });
+}
+
+function replaceInBlock(node, field, replace) {
+    var i, newNodes,
+        body = node[field],
+        single = body instanceof uglifyJS.AST_Node;
+
+    if (body === null || body === undefined) {
+        return;
     }
 
-    function replaceInBlock(node, field, replace) {
-        var i, newNodes,
-            body = node[field],
-            single = body instanceof uglifyJS.AST_Node;
+    if (single) {
+        body = [body];
+    }
 
-        if (body === null || body === undefined) {
-            return;
-        }
-
-        if (single) {
-            body = [body];
-        }
-
-        i = 0;
-        while (i < body.length) {
-            newNodes = replace(body[i], i, body);
-            if (newNodes) {
-                newNodes.unshift(i, 1);
-                Array.prototype.splice.apply(body, newNodes);
-            } else {
-                i += 1;
-            }
-        }
-
-        if (single) {
-            if (body.length === 1) {
-                node[field] = body[0];
-            } else {
-                node[field] = new uglifyJS.AST_BlockStatement({body: body});
-            }
+    i = 0;
+    while (i < body.length) {
+        newNodes = replace(body[i], i, body);
+        if (newNodes) {
+            newNodes.unshift(i, 1);
+            Array.prototype.splice.apply(body, newNodes);
+        } else {
+            i += 1;
         }
     }
 
-    function removeSequences(node, field) {
-        var nodeTypes = [
-            { type: uglifyJS.AST_Return, field: "value" },
-            { type: uglifyJS.AST_SimpleStatement, field: "body" },
-            { type: uglifyJS.AST_If, field: "condition" },
-            { type: uglifyJS.AST_For, field: "init" },
-            { type: uglifyJS.AST_With, field: "expression" },
-            { type: uglifyJS.AST_Switch, field: "expression" }
-        ];
+    if (single) {
+        if (body.length === 1) {
+            node[field] = body[0];
+        } else {
+            node[field] = new uglifyJS.AST_BlockStatement({body: body});
+        }
+    }
+}
 
-        replaceInBlock(node, field, function (child) {
-            var j, seq;
+function removeSequences(node, field) {
+    var nodeTypes = [
+        { type: uglifyJS.AST_Return, field: "value" },
+        { type: uglifyJS.AST_SimpleStatement, field: "body" },
+        { type: uglifyJS.AST_If, field: "condition" },
+        { type: uglifyJS.AST_For, field: "init" },
+        { type: uglifyJS.AST_With, field: "expression" },
+        { type: uglifyJS.AST_Switch, field: "expression" }
+    ];
 
-            if (child instanceof uglifyJS.AST_Var) {
-                for (j = 0; j < child.definitions.length; j += 1) {
-                    if (child.definitions[j].value instanceof uglifyJS.AST_Seq) {
-                        seq = child.definitions[j].value;
-                        child.definitions[j].value = seq.cdr;
-                        return [new uglifyJS.AST_SimpleStatement({body: seq.car}), child];
-                    }
-                }
-            }
+    replaceInBlock(node, field, function (child) {
+        var j, seq;
 
-            if (child instanceof uglifyJS.AST_SimpleStatement &&
-                    child.body instanceof uglifyJS.AST_Assign &&
-                    child.body.right instanceof uglifyJS.AST_Seq) {
-                seq = child.body.right;
-                child.body.right = seq.cdr;
-                return [new uglifyJS.AST_SimpleStatement({body: seq.car}), child];
-            }
-
-            for (j = 0; j < nodeTypes.length; j += 1) {
-                if (child instanceof nodeTypes[j].type && child[nodeTypes[j].field] instanceof uglifyJS.AST_Seq) {
-                    seq = child[nodeTypes[j].field];
-                    child[nodeTypes[j].field] = seq.cdr;
+        if (child instanceof uglifyJS.AST_Var) {
+            for (j = 0; j < child.definitions.length; j += 1) {
+                if (child.definitions[j].value instanceof uglifyJS.AST_Seq) {
+                    seq = child.definitions[j].value;
+                    child.definitions[j].value = seq.cdr;
                     return [new uglifyJS.AST_SimpleStatement({body: seq.car}), child];
                 }
             }
-        });
+        }
+
+        if (child instanceof uglifyJS.AST_SimpleStatement &&
+                child.body instanceof uglifyJS.AST_Assign &&
+                child.body.right instanceof uglifyJS.AST_Seq) {
+            seq = child.body.right;
+            child.body.right = seq.cdr;
+            return [new uglifyJS.AST_SimpleStatement({body: seq.car}), child];
+        }
+
+        for (j = 0; j < nodeTypes.length; j += 1) {
+            if (child instanceof nodeTypes[j].type && child[nodeTypes[j].field] instanceof uglifyJS.AST_Seq) {
+                seq = child[nodeTypes[j].field];
+                child[nodeTypes[j].field] = seq.cdr;
+                return [new uglifyJS.AST_SimpleStatement({body: seq.car}), child];
+            }
+        }
+    });
+}
+
+function transformBefore(node) {
+    if (this.options.constants) {
+        /* 0/0 => NaN */
+        if (node instanceof uglifyJS.AST_Binary && node.operator === "/" &&
+                node.left instanceof uglifyJS.AST_Number && node.left.value === 0 &&
+                node.right instanceof uglifyJS.AST_Number && node.right.value === 0) {
+            return new uglifyJS.AST_NaN();
+        }
+
+        /* 1/0 => Infinity */
+        if (node instanceof uglifyJS.AST_Binary && node.operator === "/" &&
+                node.left instanceof uglifyJS.AST_Number && node.left.value === 1 &&
+                node.right instanceof uglifyJS.AST_Number && node.right.value === 0) {
+            return new uglifyJS.AST_Infinity();
+        }
+
+        /* !0 => true, !1 => false */
+        if (node instanceof uglifyJS.AST_UnaryPrefix && node.operator === "!" &&
+                node.expression instanceof uglifyJS.AST_Number) {
+            if (node.expression.value === 0) {
+                return new uglifyJS.AST_True();
+            }
+            if (node.expression.value === 1) {
+                return new uglifyJS.AST_False();
+            }
+        }
     }
 
-    function transformBefore(node) {
-        if (this.options.constants) {
-            /* 0/0 => NaN */
-            if (node instanceof uglifyJS.AST_Binary && node.operator === "/" &&
-                    node.left instanceof uglifyJS.AST_Number && node.left.value === 0 &&
-                    node.right instanceof uglifyJS.AST_Number && node.right.value === 0) {
-                return new uglifyJS.AST_NaN();
-            }
-
-            /* 1/0 => Infinity */
-            if (node instanceof uglifyJS.AST_Binary && node.operator === "/" &&
-                    node.left instanceof uglifyJS.AST_Number && node.left.value === 1 &&
-                    node.right instanceof uglifyJS.AST_Number && node.right.value === 0) {
-                return new uglifyJS.AST_Infinity();
-            }
-
-            /* !0 => true, !1 => false */
-            if (node instanceof uglifyJS.AST_UnaryPrefix && node.operator === "!" &&
-                    node.expression instanceof uglifyJS.AST_Number) {
-                if (node.expression.value === 0) {
-                    return new uglifyJS.AST_True();
-                }
-                if (node.expression.value === 1) {
-                    return new uglifyJS.AST_False();
-                }
+    if (this.options.sequences) {
+        if (node instanceof uglifyJS.AST_Block) {
+            removeSequences(node, "body");
+        } else if (node instanceof uglifyJS.AST_StatementWithBody) {
+            removeSequences(node, "body");
+            if (node instanceof uglifyJS.AST_If) {
+                removeSequences(node, "alternative");
             }
         }
+    }
 
-        if (this.options.sequences) {
-            if (node instanceof uglifyJS.AST_Block) {
-                removeSequences(node, "body");
-            } else if (node instanceof uglifyJS.AST_StatementWithBody) {
-                removeSequences(node, "body");
-                if (node instanceof uglifyJS.AST_If) {
-                    removeSequences(node, "alternative");
-                }
-            }
-        }
-
-        if (this.options.conditionals) {
-            if (node instanceof uglifyJS.AST_SimpleStatement && node.body instanceof uglifyJS.AST_Binary) {
-                /* a && b; => if (a) { b; } */
-                if (node.body.operator === "&&") {
-                    node = new uglifyJS.AST_If({
-                        condition: node.body.left,
-                        body: asStatement(node.body.right),
-                        alternative: null
-                    });
-                    node.transform(this);
-                    return node;
-                }
-                /* a || b; => if (!a) { b; } */
-                if (node.body.operator === "||") {
-                    node = new uglifyJS.AST_If({
-                        condition: new uglifyJS.AST_UnaryPrefix({operator: "!", expression: node.body.left}),
-                        body: asStatement(node.body.right),
-                        alternative: null
-                    });
-                    node.transform(this);
-                    return node;
-                }
-            }
-
-            /* a ? b : c; => if (a) { b; } else { c; } */
-            if (node instanceof uglifyJS.AST_SimpleStatement && node.body instanceof uglifyJS.AST_Conditional) {
+    if (this.options.conditionals) {
+        if (node instanceof uglifyJS.AST_SimpleStatement && node.body instanceof uglifyJS.AST_Binary) {
+            /* a && b; => if (a) { b; } */
+            if (node.body.operator === "&&") {
                 node = new uglifyJS.AST_If({
-                    condition: node.body.condition,
-                    body: asStatement(node.body.consequent),
-                    alternative: asStatement(node.body.alternative)
+                    condition: node.body.left,
+                    body: asStatement(node.body.right),
+                    alternative: null
                 });
                 node.transform(this);
                 return node;
             }
-
-            /* return a ? b : c; => if (a) { return b; } else { return c; } */
-            if (node instanceof uglifyJS.AST_Return && node.value instanceof uglifyJS.AST_Conditional) {
+            /* a || b; => if (!a) { b; } */
+            if (node.body.operator === "||") {
                 node = new uglifyJS.AST_If({
-                    condition: node.value.condition,
-                    body: new uglifyJS.AST_Return({ value: node.value.consequent }),
-                    alternative: new uglifyJS.AST_Return({ value: node.value.alternative })
+                    condition: new uglifyJS.AST_UnaryPrefix({operator: "!", expression: node.body.left}),
+                    body: asStatement(node.body.right),
+                    alternative: null
                 });
                 node.transform(this);
                 return node;
             }
-
-            /* return void a(); => a(); return; */
-            if (node instanceof uglifyJS.AST_Block || node instanceof uglifyJS.AST_StatementWithBody) {
-                replaceInBlock(node, "body", function (child) {
-                    if (child instanceof uglifyJS.AST_Return &&
-                            child.value instanceof uglifyJS.AST_UnaryPrefix &&
-                            child.value.operator === "void") {
-                        return [new uglifyJS.AST_SimpleStatement({ body: child.value.expression }),
-                                new uglifyJS.AST_Return({ value: null }) ];
-                    }
-                });
-            }
         }
-    }
 
-    function decompress(node, options) {
-        var k, transform;
+        /* a ? b : c; => if (a) { b; } else { c; } */
+        if (node instanceof uglifyJS.AST_SimpleStatement && node.body instanceof uglifyJS.AST_Conditional) {
+            node = new uglifyJS.AST_If({
+                condition: node.body.condition,
+                body: asStatement(node.body.consequent),
+                alternative: asStatement(node.body.alternative)
+            });
+            node.transform(this);
+            return node;
+        }
 
-        if (options === undefined) {
-            options = defaultOptions;
-        } else {
-            for (k in defaultOptions) {
-                if (defaultOptions.hasOwnProperty(k) && options[k] === undefined) {
-                    options[k] = defaultOptions[k];
+        /* return a ? b : c; => if (a) { return b; } else { return c; } */
+        if (node instanceof uglifyJS.AST_Return && node.value instanceof uglifyJS.AST_Conditional) {
+            node = new uglifyJS.AST_If({
+                condition: node.value.condition,
+                body: new uglifyJS.AST_Return({ value: node.value.consequent }),
+                alternative: new uglifyJS.AST_Return({ value: node.value.alternative })
+            });
+            node.transform(this);
+            return node;
+        }
+
+        /* return void a(); => a(); return; */
+        if (node instanceof uglifyJS.AST_Block || node instanceof uglifyJS.AST_StatementWithBody) {
+            replaceInBlock(node, "body", function (child) {
+                if (child instanceof uglifyJS.AST_Return &&
+                        child.value instanceof uglifyJS.AST_UnaryPrefix &&
+                        child.value.operator === "void") {
+                    return [new uglifyJS.AST_SimpleStatement({ body: child.value.expression }),
+                            new uglifyJS.AST_Return({ value: null }) ];
                 }
+            });
+        }
+    }
+}
+
+function decompress(node, options) {
+    var k, transform;
+
+    if (options === undefined) {
+        options = defaultOptions;
+    } else {
+        for (k in defaultOptions) {
+            if (defaultOptions.hasOwnProperty(k) && options[k] === undefined) {
+                options[k] = defaultOptions[k];
             }
         }
-
-        transform = new uglifyJS.TreeTransformer(transformBefore);
-        transform.options = options;
-        node.transform(transform);
     }
 
-    module.exports = decompress;
-}());
+    transform = new uglifyJS.TreeTransformer(transformBefore);
+    transform.options = options;
+    node.transform(transform);
+}
+
+module.exports = decompress;

--- a/test/test.js
+++ b/test/test.js
@@ -1,207 +1,205 @@
 /*jslint node: true */
 /*global describe, it */
-(function () {
-    "use strict";
+"use strict";
 
-    var assert = require("assert"),
-        path = require("path"),
-        fs = require("fs"),
-        uglifyJS = require("uglifyjs"),
-        here = path.dirname(module.filename),
-        suffix = process.env.TEST_COV ? "-cov" : "",
-        unbrowserify = require("../unbrowserify" + suffix),
-        decompress = require("../decompress" + suffix);
+var assert = require("assert"),
+    path = require("path"),
+    fs = require("fs"),
+    uglifyJS = require("uglifyjs"),
+    here = path.dirname(module.filename),
+    suffix = process.env.TEST_COV ? "-cov" : "",
+    unbrowserify = require("../unbrowserify" + suffix),
+    decompress = require("../decompress" + suffix);
 
-    function parseString(code, filename) {
-        var ast = uglifyJS.parse(code, {filename: filename});
-        ast.figure_out_scope();
-        return ast;
+function parseString(code, filename) {
+    var ast = uglifyJS.parse(code, {filename: filename});
+    ast.figure_out_scope();
+    return ast;
+}
+
+function formatCode(ast) {
+    return ast.print_to_string({
+        beautify: true,
+        ascii_only: true,
+        bracketize: true
+    });
+}
+
+Object.values = function (obj) {
+    var key, values = [];
+    for (key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            values.push(obj[key]);
+        }
+    }
+    return values;
+};
+
+describe("unbrowserify", function () {
+    describe("formatCode", function () {
+        it("should output each var on a new line", function () {
+            var ast = parseString("var a = 1, b = 2, c = 3;");
+            assert.equal(formatCode(ast), "var a = 1,\n    b = 2,\n    c = 3;");
+        });
+
+        it("should keep vars in a for on the same line", function () {
+            var ast = parseString("for (var i = 0, j = 0; ;) {}");
+            assert.equal(formatCode(ast), "for (var i = 0, j = 0; ;) {}");
+        });
+    });
+
+    describe("findMainFunction", function () {
+        it("should find the main function", function () {
+            var ast = parseString("var foo; !function e(){ }(foo);"),
+                f = unbrowserify.findMainFunction(ast);
+
+            assert.equal(f instanceof uglifyJS.AST_Call, true);
+            assert.equal(f.expression.name.name, "e");
+        });
+
+        it("should find the first function if multiple defined", function () {
+            var ast = parseString("var foo; !function e(){ }(foo); !function f(){ }(foo);"),
+                f = unbrowserify.findMainFunction(ast);
+
+            assert.equal(f instanceof uglifyJS.AST_Call, true);
+            assert.equal(f.expression.name.name, "e");
+        });
+
+        it("should return undefined if no functions are defined", function () {
+            var ast = parseString("var foo;"),
+                f = unbrowserify.findMainFunction(ast);
+
+            assert.equal(f, undefined);
+        });
+    });
+
+    function extractHelper(bundleFilename, test) {
+        var bundle = path.resolve(here, "fib", bundleFilename),
+            bundleSource = fs.readFileSync(bundle, "utf8"),
+            ast = parseString(bundleSource, bundle),
+            mainFunction = unbrowserify.findMainFunction(ast),
+            moduleObject = mainFunction.args[0],
+            main = mainFunction.args[2],
+            moduleNames = unbrowserify.extractModuleNames(moduleObject, main);
+
+        test(moduleObject, moduleNames);
     }
 
-    function formatCode(ast) {
-        return ast.print_to_string({
-            beautify: true,
-            ascii_only: true,
-            bracketize: true
+    describe("extractModuleNames", function () {
+        it("should find the module names", function () {
+            extractHelper("bundle.js", function (moduleObject, moduleNames) {
+                var modules = Object.values(moduleNames).sort();
+                assert.deepEqual(modules, ["fib", "main"]);
+            });
+        });
+
+        it("should find the module names after compression", function () {
+            extractHelper("bundle-min.js", function (moduleObject, moduleNames) {
+                var modules = Object.values(moduleNames).sort();
+                assert.deepEqual(modules, ["fib", "main"]);
+            });
+        });
+    });
+
+    describe("extractModules", function () {
+        var fib = path.resolve(here, "fib", "fib.js"),
+            fibSource = fs.readFileSync(fib, "utf8"),
+            expected = parseString(fibSource, fib);
+
+        it("should find the modules", function () {
+            extractHelper("bundle.js", function (moduleObject, moduleNames) {
+                var modules = unbrowserify.extractModules(moduleObject, moduleNames);
+
+                assert.ok(modules.main instanceof uglifyJS.AST_Toplevel);
+                assert.ok(modules.fib instanceof uglifyJS.AST_Toplevel);
+
+                /* Check round-trip. */
+                assert.equal(formatCode(modules.fib), formatCode(expected));
+            });
+        });
+
+        it("should find the modules after compression", function () {
+            extractHelper("bundle-min.js", function (moduleObject, moduleNames) {
+                var modules = unbrowserify.extractModules(moduleObject, moduleNames);
+
+                assert.ok(modules.main instanceof uglifyJS.AST_Toplevel);
+                assert.ok(modules.fib instanceof uglifyJS.AST_Toplevel);
+
+                /* The code for the two modules is no longer equal, because it has been compressed. */
+            });
+        });
+    });
+});
+
+describe("decompress", function () {
+    var directory = path.resolve(here, "decompress");
+
+    function findTestFiles() {
+        var isJs = /\.js$/;
+        return fs.readdirSync(directory).filter(function (name) {
+            return isJs.test(name);
         });
     }
 
-    Object.values = function (obj) {
-        var key, values = [];
-        for (key in obj) {
-            if (obj.hasOwnProperty(key)) {
-                values.push(obj[key]);
+    function getTestCases(filename) {
+        var code = fs.readFileSync(path.resolve(directory, filename), "utf8"),
+            ast = parseString(code, filename),
+            inTest = false,
+            testCase,
+            cases = [],
+            tw;
+
+        tw = new uglifyJS.TreeWalker(function (node, descend) {
+            var name;
+
+            if (node instanceof uglifyJS.AST_LabeledStatement) {
+                name = node.label.name;
+
+                if (this.parent() instanceof uglifyJS.AST_Toplevel) {
+                    testCase = {name: name};
+                    cases.push(testCase);
+                    inTest = true;
+                    descend();
+                    inTest = false;
+                    return true;
+                }
+
+                if (name === "description") {
+                    testCase[name] = node.body.start.value;
+                    return true;
+                }
+
+                if (name === "input" || name === "expect") {
+                    testCase[name] = node.body;
+                    return true;
+                }
+
+                throw new Error("Unsupported label '" + name + "' at line " + node.label.start.line);
             }
-        }
-        return values;
-    };
 
-    describe("unbrowserify", function () {
-        describe("formatCode", function () {
-            it("should output each var on a new line", function () {
-                var ast = parseString("var a = 1, b = 2, c = 3;");
-                assert.equal(formatCode(ast), "var a = 1,\n    b = 2,\n    c = 3;");
-            });
-
-            it("should keep vars in a for on the same line", function () {
-                var ast = parseString("for (var i = 0, j = 0; ;) {}");
-                assert.equal(formatCode(ast), "for (var i = 0, j = 0; ;) {}");
-            });
+            if (!inTest && !(node instanceof uglifyJS.AST_Toplevel)) {
+                throw new Error("Unsupported statement " + node.TYPE + " at line " + node.start.line);
+            }
         });
+        ast.walk(tw);
 
-        describe("findMainFunction", function () {
-            it("should find the main function", function () {
-                var ast = parseString("var foo; !function e(){ }(foo);"),
-                    f = unbrowserify.findMainFunction(ast);
+        return cases;
+    }
 
-                assert.equal(f instanceof uglifyJS.AST_Call, true);
-                assert.equal(f.expression.name.name, "e");
-            });
+    findTestFiles().forEach(function (filename) {
+        describe(filename, function () {
+            getTestCases(filename).forEach(function (testCase) {
+                it(testCase.description || testCase.name, function () {
+                    var output, expect;
 
-            it("should find the first function if multiple defined", function () {
-                var ast = parseString("var foo; !function e(){ }(foo); !function f(){ }(foo);"),
-                    f = unbrowserify.findMainFunction(ast);
+                    decompress(testCase.input);
 
-                assert.equal(f instanceof uglifyJS.AST_Call, true);
-                assert.equal(f.expression.name.name, "e");
-            });
+                    output = formatCode(testCase.input);
+                    expect = formatCode(testCase.expect);
 
-            it("should return undefined if no functions are defined", function () {
-                var ast = parseString("var foo;"),
-                    f = unbrowserify.findMainFunction(ast);
-
-                assert.equal(f, undefined);
-            });
-        });
-
-        function extractHelper(bundleFilename, test) {
-            var bundle = path.resolve(here, "fib", bundleFilename),
-                bundleSource = fs.readFileSync(bundle, "utf8"),
-                ast = parseString(bundleSource, bundle),
-                mainFunction = unbrowserify.findMainFunction(ast),
-                moduleObject = mainFunction.args[0],
-                main = mainFunction.args[2],
-                moduleNames = unbrowserify.extractModuleNames(moduleObject, main);
-
-            test(moduleObject, moduleNames);
-        }
-
-        describe("extractModuleNames", function () {
-            it("should find the module names", function () {
-                extractHelper("bundle.js", function (moduleObject, moduleNames) {
-                    var modules = Object.values(moduleNames).sort();
-                    assert.deepEqual(modules, ["fib", "main"]);
-                });
-            });
-
-            it("should find the module names after compression", function () {
-                extractHelper("bundle-min.js", function (moduleObject, moduleNames) {
-                    var modules = Object.values(moduleNames).sort();
-                    assert.deepEqual(modules, ["fib", "main"]);
-                });
-            });
-        });
-
-        describe("extractModules", function () {
-            var fib = path.resolve(here, "fib", "fib.js"),
-                fibSource = fs.readFileSync(fib, "utf8"),
-                expected = parseString(fibSource, fib);
-
-            it("should find the modules", function () {
-                extractHelper("bundle.js", function (moduleObject, moduleNames) {
-                    var modules = unbrowserify.extractModules(moduleObject, moduleNames);
-
-                    assert.ok(modules.main instanceof uglifyJS.AST_Toplevel);
-                    assert.ok(modules.fib instanceof uglifyJS.AST_Toplevel);
-
-                    /* Check round-trip. */
-                    assert.equal(formatCode(modules.fib), formatCode(expected));
-                });
-            });
-
-            it("should find the modules after compression", function () {
-                extractHelper("bundle-min.js", function (moduleObject, moduleNames) {
-                    var modules = unbrowserify.extractModules(moduleObject, moduleNames);
-
-                    assert.ok(modules.main instanceof uglifyJS.AST_Toplevel);
-                    assert.ok(modules.fib instanceof uglifyJS.AST_Toplevel);
-
-                    /* The code for the two modules is no longer equal, because it has been compressed. */
+                    assert.equal(output, expect);
                 });
             });
         });
     });
-
-    describe("decompress", function () {
-        var directory = path.resolve(here, "decompress");
-
-        function findTestFiles() {
-            var isJs = /\.js$/;
-            return fs.readdirSync(directory).filter(function (name) {
-                return isJs.test(name);
-            });
-        }
-
-        function getTestCases(filename) {
-            var code = fs.readFileSync(path.resolve(directory, filename), "utf8"),
-                ast = parseString(code, filename),
-                inTest = false,
-                testCase,
-                cases = [],
-                tw;
-
-            tw = new uglifyJS.TreeWalker(function (node, descend) {
-                var name;
-
-                if (node instanceof uglifyJS.AST_LabeledStatement) {
-                    name = node.label.name;
-
-                    if (this.parent() instanceof uglifyJS.AST_Toplevel) {
-                        testCase = {name: name};
-                        cases.push(testCase);
-                        inTest = true;
-                        descend();
-                        inTest = false;
-                        return true;
-                    }
-
-                    if (name === "description") {
-                        testCase[name] = node.body.start.value;
-                        return true;
-                    }
-
-                    if (name === "input" || name === "expect") {
-                        testCase[name] = node.body;
-                        return true;
-                    }
-
-                    throw new Error("Unsupported label '" + name + "' at line " + node.label.start.line);
-                }
-
-                if (!inTest && !(node instanceof uglifyJS.AST_Toplevel)) {
-                    throw new Error("Unsupported statement " + node.TYPE + " at line " + node.start.line);
-                }
-            });
-            ast.walk(tw);
-
-            return cases;
-        }
-
-        findTestFiles().forEach(function (filename) {
-            describe(filename, function () {
-                getTestCases(filename).forEach(function (testCase) {
-                    it(testCase.description || testCase.name, function () {
-                        var output, expect;
-
-                        decompress(testCase.input);
-
-                        output = formatCode(testCase.input);
-                        expect = formatCode(testCase.expect);
-
-                        assert.equal(output, expect);
-                    });
-                });
-            });
-        });
-    });
-}());
+});

--- a/unbrowserify.js
+++ b/unbrowserify.js
@@ -235,12 +235,6 @@ function unbrowserify(filename, outputDirectory) {
             outputCode(module, moduleFile);
         }
     }
-
-    // console.log(JSON.stringify(moduleNames, undefined, 2));
-
-    // modules = extractModules(moduleObject);
-    // console.log(ast);
-    //outputCode(ast);
 }
 
 module.exports = {

--- a/unbrowserify.js
+++ b/unbrowserify.js
@@ -1,254 +1,252 @@
 /*jslint node: true */
-(function () {
-    "use strict";
+"use strict";
 
-    var uglifyJS = require("uglifyjs"),
-        fs = require("fs"),
-        path = require("path"),
-        decompress = require("./decompress");
+var uglifyJS = require("uglifyjs"),
+    fs = require("fs"),
+    path = require("path"),
+    decompress = require("./decompress");
 
-    /* Override printing of variable definitions to output each var on a separate line. */
-    uglifyJS.AST_Definitions.prototype._do_print = function (output, kind) {
-        var self = this,
-            p = output.parent(),
-            inFor = (p instanceof uglifyJS.AST_For || p instanceof uglifyJS.AST_ForIn) && p.init === this;
+/* Override printing of variable definitions to output each var on a separate line. */
+uglifyJS.AST_Definitions.prototype._do_print = function (output, kind) {
+    var self = this,
+        p = output.parent(),
+        inFor = (p instanceof uglifyJS.AST_For || p instanceof uglifyJS.AST_ForIn) && p.init === this;
 
-        output.print(kind);
-        output.space();
+    output.print(kind);
+    output.space();
 
-        if (inFor) {
-            this.definitions.forEach(function (def, i) {
+    if (inFor) {
+        this.definitions.forEach(function (def, i) {
+            if (i !== 0) {
+                output.comma();
+            }
+            def.print(output);
+        });
+    } else {
+        output.with_indent(output.indentation() + 4, function () {
+            self.definitions.forEach(function (def, i) {
                 if (i !== 0) {
-                    output.comma();
+                    output.print(",");
+                    output.newline();
+                    output.indent();
                 }
+
                 def.print(output);
             });
-        } else {
-            output.with_indent(output.indentation() + 4, function () {
-                self.definitions.forEach(function (def, i) {
-                    if (i !== 0) {
-                        output.print(",");
-                        output.newline();
-                        output.indent();
-                    }
-
-                    def.print(output);
-                });
-            });
-
-            output.semicolon();
-        }
-    };
-
-    function parseFile(filename) {
-        var code = fs.readFileSync(filename, "utf8"),
-            ast = uglifyJS.parse(code, {filename: filename});
-
-        ast.figure_out_scope();
-        return ast;
-    }
-
-    function outputCode(ast, filename) {
-        var options = {
-                beautify: true,
-                ascii_only: true,
-                bracketize: true
-            },
-            code = ast.print_to_string(options);
-
-        if (filename) {
-            fs.writeFileSync(filename, code);
-        } else {
-            console.log(code);
-        }
-    }
-
-    function findMainFunction(ast) {
-        var mainFunctionCall,
-            visitor;
-
-        visitor = new uglifyJS.TreeWalker(function (node) {
-            if (node instanceof uglifyJS.AST_Call) {
-                if (mainFunctionCall === undefined) {
-                    mainFunctionCall = node;
-                } else {
-                    console.warn("More than one top-level function found.");
-                }
-                return true;
-            }
         });
 
-        ast.walk(visitor);
-        return mainFunctionCall;
+        output.semicolon();
     }
+};
 
-    function extractModuleNames(moduleObject, main) {
-        var moduleNames = {};
+function parseFile(filename) {
+    var code = fs.readFileSync(filename, "utf8"),
+        ast = uglifyJS.parse(code, {filename: filename});
 
-        main.elements.forEach(function (element) {
-            moduleNames[element.value] = "main";
-        });
+    ast.figure_out_scope();
+    return ast;
+}
 
-        moduleObject.properties.forEach(function (objectProperty) {
-            var moduleId = objectProperty.key,
-                moduleFunction = objectProperty.value.elements[0],
-                requireMapping = objectProperty.value.elements[1];
+function outputCode(ast, filename) {
+    var options = {
+            beautify: true,
+            ascii_only: true,
+            bracketize: true
+        },
+        code = ast.print_to_string(options);
 
-            /* TODO: Resolve module names relative to output directory. */
-
-            requireMapping.properties.forEach(function (prop) {
-                var name = path.basename(prop.key, ".js"),
-                    id = prop.value.value;
-
-                if (!moduleNames[id]) {
-                    moduleNames[id] = name;
-                } else if (moduleNames[id].toLowerCase() !== name.toLowerCase()) {
-                    console.warn("More than one name found for module " + id + ":");
-                    console.warn("    " + moduleNames[id]);
-                    console.warn("    " + name);
-                }
-            });
-        });
-
-        return moduleNames;
+    if (filename) {
+        fs.writeFileSync(filename, code);
+    } else {
+        console.log(code);
     }
+}
 
-    function renameArguments(moduleFunction) {
-        var argNames = [
-            "require", "module", "exports", "moduleSource",
-            "loadedModules", "mainIds"
-        ];
+function findMainFunction(ast) {
+    var mainFunctionCall,
+        visitor;
 
-        /* Rename the function arguments (if needed). The code generator has
-         * special logic to display the mangled name if it's present. */
-        moduleFunction.argnames.forEach(function (arg, i) {
-            if (arg.name !== argNames[i]) {
-                arg.thedef.mangled_name = argNames[i];
-            }
-        });
-    }
-
-    function updateRequires(moduleFunction, mapping) {
-        var visitor, name;
-
-        visitor = new uglifyJS.TreeWalker(function (node) {
-            if (node instanceof uglifyJS.AST_Call &&
-                    node.expression instanceof uglifyJS.AST_SymbolRef &&
-                    (node.expression.name === "require" || node.expression.thedef.mangled_name === "require") &&
-                    node.args.length === 1 &&
-                    node.args[0] instanceof uglifyJS.AST_String) {
-
-                name = path.basename(node.args[0].value, ".js");
-                if (mapping[name]) {
-                    node.args[0].value = "./" + mapping[name] + ".js";
-                }
-            }
-        });
-
-        moduleFunction.walk(visitor);
-    }
-
-    function extractModules(moduleObject, moduleNames) {
-        var modules = {};
-
-        modules.main = new uglifyJS.AST_Toplevel({body: []});
-
-        moduleObject.properties.forEach(function (objectProperty) {
-            var moduleId = objectProperty.key,
-                moduleFunction = objectProperty.value.elements[0],
-                requireMapping = objectProperty.value.elements[1],
-                moduleName = moduleNames[moduleId],
-                topLevel,
-                mapping = {};
-
-            requireMapping.properties.forEach(function (prop) {
-                var name = path.basename(prop.key, ".js"),
-                    id = prop.value.value;
-                mapping[name] = moduleNames[id];
-            });
-
-            if (modules[moduleName]) {
-                topLevel = modules[moduleName];
+    visitor = new uglifyJS.TreeWalker(function (node) {
+        if (node instanceof uglifyJS.AST_Call) {
+            if (mainFunctionCall === undefined) {
+                mainFunctionCall = node;
             } else {
-                topLevel = modules[moduleName] = new uglifyJS.AST_Toplevel({body: []});
+                console.warn("More than one top-level function found.");
             }
+            return true;
+        }
+    });
 
-            renameArguments(moduleFunction);
-            updateRequires(moduleFunction, mapping);
+    ast.walk(visitor);
+    return mainFunctionCall;
+}
 
-            topLevel.body = topLevel.body.concat(moduleFunction.body);
+function extractModuleNames(moduleObject, main) {
+    var moduleNames = {};
+
+    main.elements.forEach(function (element) {
+        moduleNames[element.value] = "main";
+    });
+
+    moduleObject.properties.forEach(function (objectProperty) {
+        var moduleId = objectProperty.key,
+            moduleFunction = objectProperty.value.elements[0],
+            requireMapping = objectProperty.value.elements[1];
+
+        /* TODO: Resolve module names relative to output directory. */
+
+        requireMapping.properties.forEach(function (prop) {
+            var name = path.basename(prop.key, ".js"),
+                id = prop.value.value;
+
+            if (!moduleNames[id]) {
+                moduleNames[id] = name;
+            } else if (moduleNames[id].toLowerCase() !== name.toLowerCase()) {
+                console.warn("More than one name found for module " + id + ":");
+                console.warn("    " + moduleNames[id]);
+                console.warn("    " + name);
+            }
+        });
+    });
+
+    return moduleNames;
+}
+
+function renameArguments(moduleFunction) {
+    var argNames = [
+        "require", "module", "exports", "moduleSource",
+        "loadedModules", "mainIds"
+    ];
+
+    /* Rename the function arguments (if needed). The code generator has
+     * special logic to display the mangled name if it's present. */
+    moduleFunction.argnames.forEach(function (arg, i) {
+        if (arg.name !== argNames[i]) {
+            arg.thedef.mangled_name = argNames[i];
+        }
+    });
+}
+
+function updateRequires(moduleFunction, mapping) {
+    var visitor, name;
+
+    visitor = new uglifyJS.TreeWalker(function (node) {
+        if (node instanceof uglifyJS.AST_Call &&
+                node.expression instanceof uglifyJS.AST_SymbolRef &&
+                (node.expression.name === "require" || node.expression.thedef.mangled_name === "require") &&
+                node.args.length === 1 &&
+                node.args[0] instanceof uglifyJS.AST_String) {
+
+            name = path.basename(node.args[0].value, ".js");
+            if (mapping[name]) {
+                node.args[0].value = "./" + mapping[name] + ".js";
+            }
+        }
+    });
+
+    moduleFunction.walk(visitor);
+}
+
+function extractModules(moduleObject, moduleNames) {
+    var modules = {};
+
+    modules.main = new uglifyJS.AST_Toplevel({body: []});
+
+    moduleObject.properties.forEach(function (objectProperty) {
+        var moduleId = objectProperty.key,
+            moduleFunction = objectProperty.value.elements[0],
+            requireMapping = objectProperty.value.elements[1],
+            moduleName = moduleNames[moduleId],
+            topLevel,
+            mapping = {};
+
+        requireMapping.properties.forEach(function (prop) {
+            var name = path.basename(prop.key, ".js"),
+                id = prop.value.value;
+            mapping[name] = moduleNames[id];
         });
 
-        return modules;
+        if (modules[moduleName]) {
+            topLevel = modules[moduleName];
+        } else {
+            topLevel = modules[moduleName] = new uglifyJS.AST_Toplevel({body: []});
+        }
+
+        renameArguments(moduleFunction);
+        updateRequires(moduleFunction, mapping);
+
+        topLevel.body = topLevel.body.concat(moduleFunction.body);
+    });
+
+    return modules;
+}
+
+function unbrowserify(filename, outputDirectory) {
+    var mainFunction,
+        moduleObject,
+        main,
+        modules,
+        moduleNames,
+        moduleName,
+        moduleFile,
+        module,
+        ast = parseFile(filename);
+
+    /*
+     Top level of each file should be:
+
+     function e(t, n, r){ ... }({ ... }, {}, [ ... ]);
+
+     Where the omitted parts are:
+     1) Top level implementation of `require`
+     2) Module source
+     3) Ids of the `main` module.
+
+     The module source is an object literal, the key is the module's id,
+     the value is an array containing the module function and a object
+     literal of module name to id mappings.
+     */
+
+    mainFunction = findMainFunction(ast);
+    if (!mainFunction) {
+        console.error(filename + ": unable to find main function.");
+        return;
     }
 
-    function unbrowserify(filename, outputDirectory) {
-        var mainFunction,
-            moduleObject,
-            main,
-            modules,
-            moduleNames,
-            moduleName,
-            moduleFile,
-            module,
-            ast = parseFile(filename);
+    moduleObject = mainFunction.args[0];
+    main = mainFunction.args[2];
 
-        /*
-         Top level of each file should be:
-
-         function e(t, n, r){ ... }({ ... }, {}, [ ... ]);
-
-         Where the omitted parts are:
-         1) Top level implementation of `require`
-         2) Module source
-         3) Ids of the `main` module.
-
-         The module source is an object literal, the key is the module's id,
-         the value is an array containing the module function and a object
-         literal of module name to id mappings.
-         */
-
-        mainFunction = findMainFunction(ast);
-        if (!mainFunction) {
-            console.error(filename + ": unable to find main function.");
-            return;
-        }
-
-        moduleObject = mainFunction.args[0];
-        main = mainFunction.args[2];
-
-        if (!(moduleObject instanceof uglifyJS.AST_Object)) {
-            console.error(filename + ": first argument should be an object");
-            return;
-        }
-
-        moduleNames = extractModuleNames(moduleObject, main);
-        modules = extractModules(moduleObject, moduleNames);
-
-        for (moduleName in modules) {
-            if (modules.hasOwnProperty(moduleName)) {
-                module = modules[moduleName];
-                decompress(module);
-
-                moduleFile = path.join(outputDirectory, moduleName + ".js");
-                console.log("Writing " + moduleFile);
-
-                outputCode(module, moduleFile);
-            }
-        }
-
-        // console.log(JSON.stringify(moduleNames, undefined, 2));
-
-        // modules = extractModules(moduleObject);
-        // console.log(ast);
-        //outputCode(ast);
+    if (!(moduleObject instanceof uglifyJS.AST_Object)) {
+        console.error(filename + ": first argument should be an object");
+        return;
     }
 
-    module.exports = {
-        outputCode: outputCode,
-        findMainFunction: findMainFunction,
-        extractModuleNames: extractModuleNames,
-        extractModules: extractModules,
-        unbrowserify: unbrowserify
-    };
-}());
+    moduleNames = extractModuleNames(moduleObject, main);
+    modules = extractModules(moduleObject, moduleNames);
+
+    for (moduleName in modules) {
+        if (modules.hasOwnProperty(moduleName)) {
+            module = modules[moduleName];
+            decompress(module);
+
+            moduleFile = path.join(outputDirectory, moduleName + ".js");
+            console.log("Writing " + moduleFile);
+
+            outputCode(module, moduleFile);
+        }
+    }
+
+    // console.log(JSON.stringify(moduleNames, undefined, 2));
+
+    // modules = extractModules(moduleObject);
+    // console.log(ast);
+    //outputCode(ast);
+}
+
+module.exports = {
+    outputCode: outputCode,
+    findMainFunction: findMainFunction,
+    extractModuleNames: extractModuleNames,
+    extractModules: extractModules,
+    unbrowserify: unbrowserify
+};


### PR DESCRIPTION
Remove wrapper functions because Node.js has a module wrapper function builtin, so you can't pollute the global namespace like you can in the browser. Also, remove some dead code.
